### PR TITLE
feat: touch file after successful ECC

### DIFF
--- a/eccProg.py
+++ b/eccProg.py
@@ -1,24 +1,26 @@
 #!/usr/bin/env python3
 
+from pathlib import Path
+from time import sleep
+import logging
 import os
 import subprocess
-from time import sleep
 
 print("Nebra ECC Tool")
 
 preTestFail = 0
 afterTestFail = 0
 
-from pathlib import Path
-import logging
 ECC_SUCCESSFUL_TOUCH_FILEPATH = "/var/data/gwmfr_ecc_provisioned"
 logging.basicConfig(level=os.environ.get("LOGLEVEL", "DEBUG"))
+
 
 # https://stackoverflow.com/questions/1158076/implement-touch-using-python
 def record_successful_provision():
     logging.debug("ECC provisioning complete")
     Path(ECC_SUCCESSFUL_TOUCH_FILEPATH).touch()
     logging.debug("ECC provisioning recorded. Touched to %s" % ECC_SUCCESSFUL_TOUCH_FILEPATH)
+
 
 while preTestFail < 10:
     preTest = subprocess.run(["/opt/gateway_mfr/bin/gateway_mfr", "ecc", "onboarding"], capture_output=True)

--- a/eccProg.py
+++ b/eccProg.py
@@ -9,6 +9,17 @@ print("Nebra ECC Tool")
 preTestFail = 0
 afterTestFail = 0
 
+from pathlib import Path
+import logging
+ECC_SUCCESSFUL_TOUCH_FILEPATH = "/var/data/gwmfr_ecc_provisioned"
+logging.basicConfig(level=os.environ.get("LOGLEVEL", "DEBUG"))
+
+# https://stackoverflow.com/questions/1158076/implement-touch-using-python
+def record_successful_provision():
+    logging.debug("ECC provisioning complete")
+    Path(ECC_SUCCESSFUL_TOUCH_FILEPATH).touch()
+    logging.debug("ECC provisioning recorded. Touched to %s" % ECC_SUCCESSFUL_TOUCH_FILEPATH)
+
 while preTestFail < 10:
     preTest = subprocess.run(["/opt/gateway_mfr/bin/gateway_mfr", "ecc", "onboarding"], capture_output=True)
     preTestResult = str(preTest.stdout.decode('ascii')).rstrip()
@@ -38,6 +49,7 @@ if "ecc_response_exec_error" in preTestResult:
             sleep(2)
         elif (len(afterTestResult) == 51 or len(afterTestResult) == 52):
             print("\033[92mProgramming Success!\033[0m")
+            record_successful_provision()
             break
         else:
             print("\033[91mAn Unknown Error Occured\033[0m")
@@ -48,6 +60,7 @@ if "ecc_response_exec_error" in preTestResult:
 elif (len(preTestResult) == 51 or len(preTestResult) == 52):
     print("\033[93mKey Already Programmed\033[0m")
     print(preTestResult)
+    record_successful_provision()
 
 else:
     print("An Unknown Error Occured")

--- a/nebraScript.sh
+++ b/nebraScript.sh
@@ -5,7 +5,9 @@ echo "Checking for I2C device"
 mapfile -t data < <(i2cdetect -y 1)
 
 for i in $(seq 1 ${#data[@]}); do
+    # shellcheck disable=SC2206
     line=(${data[$i]})
+    # shellcheck disable=SC2068
     if echo ${line[@]:1} | grep -q 60; then
         echo "ECC is present"
         echo "Starting ECC Tool"


### PR DESCRIPTION
**Why**
Some ECC chips are being corrupted during manufacturing. There may be a race condition between gwmfr and diag. We want to wait for gwmfr to complete before running diagnostics.

**How**
Write to an empty file (AKA touch) when gwmfr completes successfully. Wait for this file to be present before running diagnostics.

**References**
- Slack convo: https://pisupply.slack.com/archives/C024BNQ1Y6T/p1632912403459500
- hm-diag: https://github.com/NebraLtd/hm-diag/pull/164
- helium-miner-software: https://github.com/NebraLtd/helium-miner-software/pull/155